### PR TITLE
Add plugin to report via Metrics.

### DIFF
--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>appmon4j</artifactId>
+        <groupId>de.is24.common</groupId>
+        <version>1.59-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>appmon4j-metrics</artifactId>
+    <name>appmon4j-metrics</name>
+    <version>1.59-SNAPSHOT</version>
+    
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>de.is24.common</groupId>
+            <artifactId>appmon4j-core</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics/src/main/java/de/is24/util/monitoring/metrics/MetricsPlugin.java
+++ b/metrics/src/main/java/de/is24/util/monitoring/metrics/MetricsPlugin.java
@@ -1,0 +1,56 @@
+package de.is24.util.monitoring.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import de.is24.util.monitoring.AbstractMonitorPlugin;
+import java.util.concurrent.TimeUnit;
+
+
+public class MetricsPlugin extends AbstractMonitorPlugin {
+  private MetricRegistry metricRegistry;
+
+  public MetricsPlugin(MetricRegistry metricRegistry) {
+    this.metricRegistry = metricRegistry;
+  }
+
+  @Override
+  public String getUniqueName() {
+    return null;
+  }
+
+  @Override
+  public void initializeCounter(String name) {
+  }
+
+  @Override
+  public void incrementCounter(String name, int increment) {
+    metricRegistry.counter(name).inc(increment);
+  }
+
+  @Override
+  public void incrementHighRateCounter(String name, int increment) {
+    incrementCounter(name, increment);
+  }
+
+  @Override
+  public void addTimerMeasurement(String name, long timing) {
+    metricRegistry.timer(name).update(timing, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public void addSingleEventTimerMeasurement(String name, long timing) {
+    metricRegistry.timer(name).update(timing, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public void addHighRateTimerMeasurement(String name, long timing) {
+    metricRegistry.timer(name).update(timing, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public void initializeTimerMeasurement(String name) {
+  }
+
+  @Override
+  public void afterRemovalNotification() {
+  }
+}

--- a/metrics/src/main/java/de/is24/util/monitoring/metrics/MetricsPlugin.java
+++ b/metrics/src/main/java/de/is24/util/monitoring/metrics/MetricsPlugin.java
@@ -23,7 +23,7 @@ public class MetricsPlugin extends AbstractMonitorPlugin {
 
   @Override
   public void incrementCounter(String name, int increment) {
-    metricRegistry.counter(name).inc(increment);
+    metricRegistry.counter(withCountersPrefix(name)).inc(increment);
   }
 
   @Override
@@ -33,17 +33,17 @@ public class MetricsPlugin extends AbstractMonitorPlugin {
 
   @Override
   public void addTimerMeasurement(String name, long timing) {
-    metricRegistry.timer(name).update(timing, TimeUnit.MILLISECONDS);
+    metricRegistry.timer(withTimersPrefix(name)).update(timing, TimeUnit.MILLISECONDS);
   }
 
   @Override
   public void addSingleEventTimerMeasurement(String name, long timing) {
-    metricRegistry.timer(name).update(timing, TimeUnit.MILLISECONDS);
+    addTimerMeasurement(name, timing);
   }
 
   @Override
   public void addHighRateTimerMeasurement(String name, long timing) {
-    metricRegistry.timer(name).update(timing, TimeUnit.MILLISECONDS);
+    addTimerMeasurement(name, timing);
   }
 
   @Override
@@ -52,5 +52,13 @@ public class MetricsPlugin extends AbstractMonitorPlugin {
 
   @Override
   public void afterRemovalNotification() {
+  }
+
+  private String withTimersPrefix(String name) {
+    return "timers." + name;
+  }
+
+  private String withCountersPrefix(String name) {
+    return "counters." + name;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <module>hystrix</module>
     <module>testutil</module>
     <module>integrationTest</module>
+    <module>metrics</module>
   </modules>
   
   <organization>


### PR DESCRIPTION
In our application we currently use the Dropwizard Metrics plugin as well as Appmon4j. Appmon4J reports to StatsD which is pretty unreliable. We'd like to stop using StatsD and report the Appmon4J data via Metrics to Graphite.

Here's a naive implementation of a Metrics plugin.